### PR TITLE
Add missing Express v4 properties to request/response objects

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -31,7 +31,10 @@ module.exports = function generateExpressVirtualRequest(data, socket) {
     remoteAddress: '127.0.0.1'
   };
   req.protocol = 'http';
-  req.body = '';
+  req.secure = false;
+  req.xhr = false;
+  req.body = {};
+  req.query = {};
 
   req.setTimeout = function(msec, cb) {
     if(callback) this.on('timeout', callback);

--- a/lib/request.js
+++ b/lib/request.js
@@ -33,8 +33,7 @@ module.exports = function generateExpressVirtualRequest(data, socket) {
   req.protocol = 'http';
   req.secure = false;
   req.xhr = false;
-  req.body = {};
-  req.query = {};
+  req.body = undefined;
 
   req.setTimeout = function(msec, cb) {
     if(callback) this.on('timeout', callback);

--- a/lib/response.js
+++ b/lib/response.js
@@ -36,6 +36,7 @@ module.exports = function generateExpressVirtualResponse(req) {
   res.headersSent = false;
   res.sendDate = true;
   res.body = '';
+  res.locals = Object.create(null);
 
   res.write = function(chunk) {
     res.body += chunk.toString();


### PR DESCRIPTION
Improve compatibility of request/response objects with [Express 4](http://expressjs.com/api.html#req).
- Add {secure, xhr, body, query} to request object
- Add {locals} to response object
